### PR TITLE
Adds response body to WrongStatusCodeError

### DIFF
--- a/Sources/TinyNetworking/Endpoint.swift
+++ b/Sources/TinyNetworking/Endpoint.swift
@@ -199,9 +199,11 @@ public struct UnknownError: Error {
 public struct WrongStatusCodeError: Error {
     public let statusCode: Int
     public let response: HTTPURLResponse?
-    public init(statusCode: Int, response: HTTPURLResponse?) {
+    public let responseBody: Data?
+    public init(statusCode: Int, response: HTTPURLResponse?, responseBody: Data?) {
         self.statusCode = statusCode
         self.response = response
+        self.responseBody = responseBody
     }
 }
 
@@ -227,7 +229,7 @@ extension URLSession {
             }
             
             guard e.expectedStatusCode(h.statusCode) else {
-                onComplete(.failure(WrongStatusCodeError(statusCode: h.statusCode, response: h)))
+                onComplete(.failure(WrongStatusCodeError(statusCode: h.statusCode, response: h, responseBody: data)))
                 return
             }
             

--- a/Tests/TinyNetworkingTests/URLSessionIntegrationTests.swift
+++ b/Tests/TinyNetworkingTests/URLSessionIntegrationTests.swift
@@ -50,6 +50,9 @@ final class URLSessionIntegrationTests: XCTestCase {
                 XCTFail("Expected an Error in Result.")
             case let .failure(error):
                 XCTAssertNotNil(error as? WrongStatusCodeError)
+                if let error = error as? WrongStatusCodeError {
+                    XCTAssertNotNil(error.responseBody)
+                }
                 expectation.fulfill()
             }
         }

--- a/Tests/TinyNetworkingTests/URLSessionIntegrationTests.swift
+++ b/Tests/TinyNetworkingTests/URLSessionIntegrationTests.swift
@@ -34,8 +34,33 @@ final class URLSessionIntegrationTests: XCTestCase {
 
         wait(for: [expectation], timeout: 1)
     }
+    
+    func testWrongStatusCodeErrorIncludesResponseBody() throws {
+        let url = URL(string: "http://www.example.com/internal-error.json")!
+        let internalErrorResponse = "{ message: \"Some troubleshooting message from the server.\" }".data(using: .utf8)!
+        
+        TinyHTTPStubURLProtocol.urls[url] = StubbedResponse(response: HTTPURLResponse(url: url, statusCode: 500, httpVersion: nil, headerFields: nil)!, data: internalErrorResponse)
+        
+        let endpoint = Endpoint<[Person]>(json: .get, url: url)
+        let expectation = self.expectation(description: "Stubbed network call")
+        
+        let task = URLSession.shared.load(endpoint) { result in
+            switch result {
+            case .success:
+                XCTFail("Expected an Error in Result.")
+            case let .failure(error):
+                XCTAssertNotNil(error as? WrongStatusCodeError)
+                expectation.fulfill()
+            }
+        }
+        
+        task.resume()
+        
+        wait(for: [expectation], timeout: 1)
+    }
 
     static var allTests = [
         ("testDataTaskRequest", testDataTaskRequest),
+        ("testWrongStatusCodeErrorIncludesResponseBody", testWrongStatusCodeErrorIncludesResponseBody)
     ]
 }


### PR DESCRIPTION
This PR adds an optional Data field to the WrongStatusCodeError struct. It contains the response body data from the server when an error is detected. Some servers may include useful troubleshooting information in the response, particularly for a 500 Internal Server Error status.