### PR TITLE
Fix code style according to Swiftlint errors

### DIFF
--- a/Sources/TinyNetworking/Endpoint.swift
+++ b/Sources/TinyNetworking/Endpoint.swift
@@ -73,10 +73,10 @@ public struct Endpoint<A> {
         accept: ContentType? = nil,
         contentType: ContentType? = nil,
         body: Data? = nil,
-        headers: [String:String] = [:],
+        headers: [String: String] = [:],
         expectedStatusCode: @escaping (Int) -> Bool = expected200to300,
         timeOutInterval: TimeInterval = 10,
-        query: [String:String] = [:],
+        query: [String: String] = [:],
         parse: @escaping (Data?, URLResponse?) -> Result<A, Error>
     ) {
         var requestUrl : URL
@@ -154,9 +154,9 @@ extension Endpoint where A == () {
         _ method: Method,
         url: URL,
         accept: ContentType? = nil,
-        headers: [String:String] = [:],
+        headers: [String: String] = [:],
         expectedStatusCode: @escaping (Int) -> Bool = expected200to300,
-        query: [String:String] = [:]
+        query: [String: String] = [:]
     ) {
         self.init(
             method,
@@ -186,9 +186,9 @@ extension Endpoint where A == () {
         url: URL,
         accept: ContentType? = .json,
         body: B,
-        headers: [String:String] = [:],
+        headers: [String: String] = [:],
         expectedStatusCode: @escaping (Int) -> Bool = expected200to300,
-        query: [String:String] = [:]
+        query: [String: String] = [:]
     ) {
         let b = try! JSONEncoder().encode(body)
         self.init(

--- a/Sources/TinyNetworking/Endpoint.swift
+++ b/Sources/TinyNetworking/Endpoint.swift
@@ -25,7 +25,7 @@ public struct Endpoint<A> {
     }
 
     /// The request for this endpoint
-    public var request: URLRequest
+    public let request: URLRequest
 
     /// This is used to (try to) parse a response into an `A`.
     var parse: (Data?, URLResponse?) -> Result<A, Error>
@@ -90,7 +90,7 @@ public struct Endpoint<A> {
             )
             requestUrl = comps.url!
         }
-        request = URLRequest(url: requestUrl)
+        var request = URLRequest(url: requestUrl)
         if let a = accept {
             request.setValue(a.rawValue, forHTTPHeaderField: "Accept")
         }
@@ -107,6 +107,7 @@ public struct Endpoint<A> {
         // bug: https://bugs.swift.org/browse/SR-6687
         request.httpBody = body
 
+        self.request = request
         self.expectedStatusCode = expectedStatusCode
         self.parse = parse
     }

--- a/Sources/TinyNetworking/Endpoint.swift
+++ b/Sources/TinyNetworking/Endpoint.swift
@@ -11,7 +11,8 @@ public func expected200to300(_ code: Int) -> Bool {
     return code >= 200 && code < 300
 }
 
-/// This describes an endpoint returning `A` values. It contains both a `URLRequest` and a way to parse the response.
+/// This describes an endpoint returning `A` values. It contains both a
+/// `URLRequest` and a way to parse the response.
 public struct Endpoint<A> {
 
     /// The HTTP Method
@@ -34,16 +35,22 @@ public struct Endpoint<A> {
 
     /// Transforms the result
     public func map<B>(_ f: @escaping (A) -> B) -> Endpoint<B> {
-        return Endpoint<B>(request: request, expectedStatusCode: expectedStatusCode, parse: { value, response in
+        return Endpoint<B>(
+            request: request,
+            expectedStatusCode: expectedStatusCode
+        ) { value, response in
             self.parse(value, response).map(f)
-        })
+        }
     }
 
     /// Transforms the result
     public func compactMap<B>(_ transform: @escaping (A) -> Result<B, Error>) -> Endpoint<B> {
-        return Endpoint<B>(request: request, expectedStatusCode: expectedStatusCode, parse: { data, response in
+        return Endpoint<B>(
+            request: request,
+            expectedStatusCode: expectedStatusCode
+        ) { data, response in
             self.parse(data, response).flatMap(transform)
-        })
+        }
     }
 
     /// Create a new Endpoint.
@@ -55,18 +62,32 @@ public struct Endpoint<A> {
     ///   - contentType: the content type for the `Content-Type` header
     ///   - body: the body of the request.
     ///   - headers: additional headers for the request
-    ///   - expectedStatusCode: the status code that's expected. If this returns false for a given status code, parsing fails.
+    ///   - expectedStatusCode: the status code that's expected. If this returns
+    ///   false for a given status code, parsing fails.
     ///   - timeOutInterval: the timeout interval for his request
     ///   - query: query parameters to append to the url
     ///   - parse: this converts a response into an `A`.
-    public init(_ method: Method, url: URL, accept: ContentType? = nil, contentType: ContentType? = nil, body: Data? = nil, headers: [String:String] = [:], expectedStatusCode: @escaping (Int) -> Bool = expected200to300, timeOutInterval: TimeInterval = 10, query: [String:String] = [:], parse: @escaping (Data?, URLResponse?) -> Result<A, Error>) {
+    public init(
+        _ method: Method,
+        url: URL,
+        accept: ContentType? = nil,
+        contentType: ContentType? = nil,
+        body: Data? = nil,
+        headers: [String:String] = [:],
+        expectedStatusCode: @escaping (Int) -> Bool = expected200to300,
+        timeOutInterval: TimeInterval = 10,
+        query: [String:String] = [:],
+        parse: @escaping (Data?, URLResponse?) -> Result<A, Error>
+    ) {
         var requestUrl : URL
         if query.isEmpty {
             requestUrl = url
         } else {
             var comps = URLComponents(url: url, resolvingAgainstBaseURL: true)!
             comps.queryItems = comps.queryItems ?? []
-            comps.queryItems!.append(contentsOf: query.map { URLQueryItem(name: $0.0, value: $0.1) })
+            comps.queryItems!.append(
+                contentsOf: query.map { URLQueryItem(name: $0.0, value: $0.1) }
+            )
             requestUrl = comps.url!
         }
         request = URLRequest(url: requestUrl)
@@ -82,7 +103,8 @@ public struct Endpoint<A> {
         request.timeoutInterval = timeOutInterval
         request.httpMethod = method.rawValue
 
-        // body *needs* to be the last property that we set, because of this bug: https://bugs.swift.org/browse/SR-6687
+        // body *needs* to be the last property that we set, because of this
+        // bug: https://bugs.swift.org/browse/SR-6687
         request.httpBody = body
 
         self.expectedStatusCode = expectedStatusCode
@@ -94,9 +116,14 @@ public struct Endpoint<A> {
     ///
     /// - Parameters:
     ///   - request: the URL request
-    ///   - expectedStatusCode: the status code that's expected. If this returns false for a given status code, parsing fails.
+    ///   - expectedStatusCode: the status code that's expected. If this returns
+    ///   false for a given status code, parsing fails.
     ///   - parse: this converts a response into an `A`.
-    public init(request: URLRequest, expectedStatusCode: @escaping (Int) -> Bool = expected200to300, parse: @escaping (Data?, URLResponse?) -> Result<A, Error>) {
+    public init(
+        request: URLRequest,
+        expectedStatusCode: @escaping (Int) -> Bool = expected200to300,
+        parse: @escaping (Data?, URLResponse?) -> Result<A, Error>
+    ) {
         self.request = request
         self.expectedStatusCode = expectedStatusCode
         self.parse = parse
@@ -120,10 +147,26 @@ extension Endpoint where A == () {
     ///   - url: the endpoint's URL
     ///   - accept: the content type for the `Accept` header
     ///   - headers: additional headers for the request
-    ///   - expectedStatusCode: the status code that's expected. If this returns false for a given status code, parsing fails.
+    ///   - expectedStatusCode: the status code that's expected. If this returns
+    ///   false for a given status code, parsing fails.
     ///   - query: query parameters to append to the url
-    public init(_ method: Method, url: URL, accept: ContentType? = nil, headers: [String:String] = [:], expectedStatusCode: @escaping (Int) -> Bool = expected200to300, query: [String:String] = [:]) {
-        self.init(method, url: url, accept: accept, headers: headers, expectedStatusCode: expectedStatusCode, query: query, parse: { _, _ in .success(()) })
+    public init(
+        _ method: Method,
+        url: URL,
+        accept: ContentType? = nil,
+        headers: [String:String] = [:],
+        expectedStatusCode: @escaping (Int) -> Bool = expected200to300,
+        query: [String:String] = [:]
+    ) {
+        self.init(
+            method,
+            url: url,
+            accept: accept,
+            headers: headers,
+            expectedStatusCode: expectedStatusCode,
+            query: query,
+            parse: { _, _ in .success(()) }
+        )
     }
 
     /// Creates a new endpoint without a parse function.
@@ -132,13 +175,33 @@ extension Endpoint where A == () {
     ///   - json: the HTTP method
     ///   - url: the endpoint's URL
     ///   - accept: the content type for the `Accept` header
-    ///   - body: the body of the request. This gets encoded using a default `JSONEncoder` instance.
+    ///   - body: the body of the request. This gets encoded using a default
+    ///   `JSONEncoder` instance.
     ///   - headers: additional headers for the request
-    ///   - expectedStatusCode: the status code that's expected. If this returns false for a given status code, parsing fails.
+    ///   - expectedStatusCode: the status code that's expected. If this returns
+    ///   false for a given status code, parsing fails.
     ///   - query: query parameters to append to the url
-    public init<B: Encodable>(json method: Method, url: URL, accept: ContentType? = .json, body: B, headers: [String:String] = [:], expectedStatusCode: @escaping (Int) -> Bool = expected200to300, query: [String:String] = [:]) {
+    public init<B: Encodable>(
+        json method: Method,
+        url: URL,
+        accept: ContentType? = .json,
+        body: B,
+        headers: [String:String] = [:],
+        expectedStatusCode: @escaping (Int) -> Bool = expected200to300,
+        query: [String:String] = [:]
+    ) {
         let b = try! JSONEncoder().encode(body)
-        self.init(method, url: url, accept: accept, contentType: .json, body: b, headers: headers, expectedStatusCode: expectedStatusCode, query: query, parse: { _, _ in .success(()) })
+        self.init(
+            method,
+            url: url,
+            accept: accept,
+            contentType: .json,
+            body: b,
+            headers: headers,
+            expectedStatusCode: expectedStatusCode,
+            query: query,
+            parse: { _, _ in .success(()) }
+        )
     }
 }
 
@@ -151,11 +214,28 @@ extension Endpoint where A: Decodable {
     ///   - url: the endpoint's URL
     ///   - accept: the content type for the `Accept` header
     ///   - headers: additional headers for the request
-    ///   - expectedStatusCode: the status code that's expected. If this returns false for a given status code, parsing fails.
+    ///   - expectedStatusCode: the status code that's expected. If this returns
+    ///   false for a given status code, parsing fails.
     ///   - query: query parameters to append to the url
     ///   - decoder: the decoder that's used for decoding `A`s.
-    public init(json method: Method, url: URL, accept: ContentType = .json, headers: [String: String] = [:], expectedStatusCode: @escaping (Int) -> Bool = expected200to300, query: [String: String] = [:], decoder: JSONDecoder = JSONDecoder()) {
-        self.init(method, url: url, accept: accept, body: nil, headers: headers, expectedStatusCode: expectedStatusCode, query: query) { data, _ in
+    public init(
+        json method: Method,
+        url: URL,
+        accept: ContentType = .json,
+        headers: [String: String] = [:],
+        expectedStatusCode: @escaping (Int) -> Bool = expected200to300,
+        query: [String: String] = [:],
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
+        self.init(
+            method,
+            url: url,
+            accept: accept,
+            body: nil,
+            headers: headers,
+            expectedStatusCode: expectedStatusCode,
+            query: query
+        ) { data, _ in
             return Result {
                 guard let dat = data else { throw NoDataError() }
                 return try decoder.decode(A.self, from: dat)
@@ -169,14 +249,34 @@ extension Endpoint where A: Decodable {
     ///   - method: the HTTP method
     ///   - url: the endpoint's URL
     ///   - accept: the content type for the `Accept` header
-    ///   - body: the body of the request. This is encoded using a default encoder.
+    ///   - body: the body of the request. This is encoded using a default
+    ///   encoder.
     ///   - headers: additional headers for the request
-    ///   - expectedStatusCode: the status code that's expected. If this returns false for a given status code, parsing fails.
+    ///   - expectedStatusCode: the status code that's expected. If this returns
+    ///   false for a given status code, parsing fails.
     ///   - query: query parameters to append to the url
     ///   - decoder: the decoder that's used for decoding `A`s.
-    public init<B: Encodable>(json method: Method, url: URL, accept: ContentType = .json, body: B? = nil, headers: [String: String] = [:], expectedStatusCode: @escaping (Int) -> Bool = expected200to300, query: [String: String] = [:], decoder: JSONDecoder = JSONDecoder()) {
+    public init<B: Encodable>(
+        json method: Method,
+        url: URL,
+        accept: ContentType = .json,
+        body: B? = nil,
+        headers: [String: String] = [:],
+        expectedStatusCode: @escaping (Int) -> Bool = expected200to300,
+        query: [String: String] = [:],
+        decoder: JSONDecoder = JSONDecoder()
+    ) {
         let b = body.map { try! JSONEncoder().encode($0) }
-        self.init(method, url: url, accept: accept, contentType: .json, body: b, headers: headers, expectedStatusCode: expectedStatusCode, query: query) { data, _ in
+        self.init(
+            method,
+            url: url,
+            accept: accept,
+            contentType: .json,
+            body: b,
+            headers: headers,
+            expectedStatusCode: expectedStatusCode,
+            query: query
+        ) { data, _ in
             return Result {
                 guard let dat = data else { throw NoDataError() }
                 return try decoder.decode(A.self, from: dat)
@@ -213,7 +313,10 @@ extension URLSession {
     ///   - e: The endpoint.
     ///   - onComplete: The completion handler.
     /// - Returns: The data task.
-    public func load<A>(_ e: Endpoint<A>, onComplete: @escaping (Result<A, Error>) -> ()) -> URLSessionDataTask {
+    public func load<A>(
+        _ e: Endpoint<A>,
+        onComplete: @escaping (Result<A, Error>) -> ()
+    ) -> URLSessionDataTask {
         let r = e.request
         let task = dataTask(with: r, completionHandler: { data, resp, err in
             if let err = err {
@@ -227,7 +330,11 @@ extension URLSession {
             }
 
             guard e.expectedStatusCode(h.statusCode) else {
-                onComplete(.failure(WrongStatusCodeError(statusCode: h.statusCode, response: h)))
+                let error = WrongStatusCodeError(
+                    statusCode: h.statusCode,
+                    response: h
+                )
+                onComplete(.failure(error))
                 return
             }
 

--- a/Sources/TinyNetworking/Endpoint.swift
+++ b/Sources/TinyNetworking/Endpoint.swift
@@ -13,7 +13,7 @@ public func expected200to300(_ code: Int) -> Bool {
 
 /// This describes an endpoint returning `A` values. It contains both a `URLRequest` and a way to parse the response.
 public struct Endpoint<A> {
-    
+
     /// The HTTP Method
     public enum Method: String {
         case get = "GET"
@@ -22,16 +22,16 @@ public struct Endpoint<A> {
         case patch = "PATCH"
         case delete = "DELETE"
     }
-    
+
     /// The request for this endpoint
     public var request: URLRequest
-    
+
     /// This is used to (try to) parse a response into an `A`.
     var parse: (Data?, URLResponse?) -> Result<A, Error>
-    
+
     /// This is used to check the status code of a response.
     var expectedStatusCode: (Int) -> Bool = expected200to300
-    
+
     /// Transforms the result
     public func map<B>(_ f: @escaping (A) -> B) -> Endpoint<B> {
         return Endpoint<B>(request: request, expectedStatusCode: expectedStatusCode, parse: { value, response in
@@ -88,8 +88,8 @@ public struct Endpoint<A> {
         self.expectedStatusCode = expectedStatusCode
         self.parse = parse
     }
-    
-    
+
+
     /// Creates a new Endpoint from a request
     ///
     /// - Parameters:
@@ -205,7 +205,7 @@ public struct WrongStatusCodeError: Error {
     }
 }
 
-extension URLSession {    
+extension URLSession {
     @discardableResult
     /// Loads an endpoint by creating (and directly resuming) a data task.
     ///
@@ -220,21 +220,20 @@ extension URLSession {
                 onComplete(.failure(err))
                 return
             }
-            
+
             guard let h = resp as? HTTPURLResponse else {
                 onComplete(.failure(UnknownError()))
                 return
             }
-            
+
             guard e.expectedStatusCode(h.statusCode) else {
                 onComplete(.failure(WrongStatusCodeError(statusCode: h.statusCode, response: h)))
                 return
             }
-            
+
             onComplete(e.parse(data,resp))
         })
         task.resume()
         return task
     }
 }
-

--- a/Tests/TinyNetworkingTests/TinyNetworkingTests.swift
+++ b/Tests/TinyNetworkingTests/TinyNetworkingTests.swift
@@ -4,19 +4,19 @@ import XCTest
 final class TinyNetworkingTests: XCTestCase {
     func testUrlWithoutParams() {
         let url = URL(string: "http://www.example.com/example.json")!
-        let endpoint = Endpoint<[String]>(json: .get, url: url)
+        let endpoint = Endpoint<[String]>(json: .get, url: url)!
         XCTAssertEqual(url, endpoint.request.url)
     }
 
     func testUrlWithParams() {
         let url = URL(string: "http://www.example.com/example.json")!
-        let endpoint = Endpoint<[String]>(json: .get, url: url, query: ["foo": "bar bar"])
+        let endpoint = Endpoint<[String]>(json: .get, url: url, query: ["foo": "bar bar"])!
         XCTAssertEqual(URL(string: "http://www.example.com/example.json?foo=bar%20bar")!, endpoint.request.url)
     }
 
     func testUrlAdditionalParams() {
         let url = URL(string: "http://www.example.com/example.json?abc=def")!
-        let endpoint = Endpoint<[String]>(json: .get, url: url, query: ["foo": "bar bar"])
+        let endpoint = Endpoint<[String]>(json: .get, url: url, query: ["foo": "bar bar"])!
         XCTAssertEqual(URL(string: "http://www.example.com/example.json?abc=def&foo=bar%20bar")!, endpoint.request.url)
     }
 

--- a/Tests/TinyNetworkingTests/URLSessionIntegrationTests.swift
+++ b/Tests/TinyNetworkingTests/URLSessionIntegrationTests.swift
@@ -17,7 +17,7 @@ final class URLSessionIntegrationTests: XCTestCase {
 
         TinyHTTPStubURLProtocol.urls[url] = StubbedResponse(response: HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!, data: exampleJSON.data(using: .utf8)!)
 
-        let endpoint = Endpoint<[Person]>(json: .get, url: url)
+        let endpoint = Endpoint<[Person]>(json: .get, url: url)!
         let expectation = self.expectation(description: "Stubbed network call")
 
         let task = URLSession.shared.load(endpoint) { result in


### PR DESCRIPTION
First of all, I love how simple the tiny-networking is. I would love to use it in my personal project.  Thank you all for such a wonderful SDK.

Most of the commits fix Swiftlint warnings or errors according to the default config. 

Before the changes, Swiftlint found 15 violations, 9 serious in the Endpoint.swift file. Now, it's completely violation free. Mainly it's just `identifier_name`, `line_length`, and `comma_spacing` violations. So none of these would break API compatibility.

However, for my own preference, I also fixed the `force_try` violation and that introduced API breaking changes which resulted that many `init` methods are now failable initializers. I am happy to revert this change and only include other non-API-breaking changes as well.

The tests are passing as well.

Not a request for anything to be changed in this repo. Just happy to share and contribute back to open source.

Let me know what you think.