### PR TITLE
URLResponse is unavailable on Linux

### DIFF
--- a/Sources/TinyNetworking/Endpoint.swift
+++ b/Sources/TinyNetworking/Endpoint.swift
@@ -1,5 +1,5 @@
 import Foundation
-#if os(Linux)
+#if canImport(FoundationNetworking)
 import FoundationNetworking
 #endif
 

--- a/Sources/TinyNetworking/Endpoint.swift
+++ b/Sources/TinyNetworking/Endpoint.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if os(Linux)
+import FoundationNetworking
+#endif
 
 /// Built-in Content Types
 public enum ContentType: String {


### PR DESCRIPTION
'URLResponse' is unavailable: This type has moved to the FoundationNetworking module. Import that module to use it.