### PR TITLE
Add Data attribute to WrongStatusCodeError

### DIFF
--- a/Sources/TinyNetworking/Endpoint.swift
+++ b/Sources/TinyNetworking/Endpoint.swift
@@ -201,9 +201,11 @@ public struct UnknownError: Error {
 public struct WrongStatusCodeError: Error {
     public let statusCode: Int
     public let response: HTTPURLResponse?
-    public init(statusCode: Int, response: HTTPURLResponse?) {
+    public let data: Data?
+    public init(statusCode: Int, response: HTTPURLResponse?, data: Data?) {
         self.statusCode = statusCode
         self.response = response
+        self.data = data
     }
 }
 
@@ -229,7 +231,7 @@ extension URLSession {
             }
             
             guard e.expectedStatusCode(h.statusCode) else {
-                onComplete(.failure(WrongStatusCodeError(statusCode: h.statusCode, response: h)))
+                onComplete(.failure(WrongStatusCodeError(statusCode: h.statusCode, response: h, data: data)))
                 return
             }
             
@@ -259,7 +261,7 @@ extension URLSession {
                 }
 
                 guard e.expectedStatusCode(h.statusCode) else {
-                    throw WrongStatusCodeError(statusCode: h.statusCode, response: h)
+                    throw WrongStatusCodeError(statusCode: h.statusCode, response: h, data: data)
                 }
 
                 return try e.parse(data, resp).get()


### PR DESCRIPTION
It is very often that APIs return important and interesting data in the body of a failed HTTP response such as a failure reason message and/or domain specific error data.

This change allows access to this data by adding a `Data?` attribute to `WrongStatusCodeError`.  Consumers of this Package can parse this data however they like or not at all. 