### PR TITLE
Add async/await extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ URLSession.shared.load(endpoint) { result in
 }
 ```
 
+Alternatively, you can use the async/await option.
+```swift
+let result = try await URLSession.shared.load(endpoint)
+``` 
+
 ## Authenticated Endpoints
 
 Here's an example of how you can have authenticated endpoints. You initialize the `Mailchimp` struct with an API key, and use that to compute an `authHeader`. You can then use the `authHeader` when you create endpoints.

--- a/Sources/TinyNetworking/Endpoint.swift
+++ b/Sources/TinyNetworking/Endpoint.swift
@@ -281,3 +281,20 @@ extension URLSession {
     }
 }
 #endif
+
+@available(iOS 15, macOS 12.0, watchOS 8, tvOS 15, *)
+public extension URLSession {
+    /// Loads the contents of a `Endpoint` and delivers the data asynchronously.
+    /// - Returns: The parsed `A` value specified in `Endpoint`
+    func load<A>(_ e: Endpoint<A>) async throws -> A {
+        let request = e.request
+        let (data, resp) = try await data(for: request)
+        guard let h = resp as? HTTPURLResponse else {
+            throw UnknownError()
+        }
+        guard e.expectedStatusCode(h.statusCode) else {
+            throw WrongStatusCodeError(statusCode: h.statusCode, response: h, responseBody: data)
+        }
+        return try e.parse(data, resp).get()
+    }
+}


### PR DESCRIPTION
This PR adds an option to load an `Endpoint` using the new async and await introduced in swift 5.5. See issue #24