### PR TITLE
Lower iOS version requirements for async/await

### DIFF
--- a/Sources/TinyNetworking/Endpoint.swift
+++ b/Sources/TinyNetworking/Endpoint.swift
@@ -283,7 +283,7 @@ extension URLSession {
 #endif
 
 #if swift(>=5.5)
-@available(iOS 13, macOS 12.0, watchOS 8, tvOS 15, *)
+@available(iOS 13, macOS 10.15, watchOS 6, tvOS 13, *)
 public extension URLSession {
     /// Loads the contents of a `Endpoint` and delivers the data asynchronously.
     /// - Returns: The parsed `A` value specified in `Endpoint`

--- a/Sources/TinyNetworking/Endpoint.swift
+++ b/Sources/TinyNetworking/Endpoint.swift
@@ -283,7 +283,7 @@ extension URLSession {
 #endif
 
 #if swift(>=5.5)
-@available(iOS 15, macOS 12.0, watchOS 8, tvOS 15, *)
+@available(iOS 13, macOS 12.0, watchOS 8, tvOS 15, *)
 public extension URLSession {
     /// Loads the contents of a `Endpoint` and delivers the data asynchronously.
     /// - Returns: The parsed `A` value specified in `Endpoint`


### PR DESCRIPTION
With the release of [Xcode 13.2](https://www.swiftbysundell.com/special/swift-concurrency-backward-compatibility/) `async`/`await` functionality is now backward compatible with iOS 13, macOS 10.15(Catalina), watchOS 6, tvOS 13.